### PR TITLE
Use integer instead of string in task-definition.json

### DIFF
--- a/reverse-proxy/task-definition.json
+++ b/reverse-proxy/task-definition.json
@@ -3,12 +3,12 @@
     {
       "name": "nginx",
       "image": "<your nginx reverse proxy image URL here>",
-      "memory": "256",
-      "cpu": "256",
+      "memory": 256,
+      "cpu": 256,
       "essential": true,
       "portMappings": [
         {
-          "containerPort": "80",
+          "containerPort": 80,
           "protocol": "tcp"
         }
       ],
@@ -19,8 +19,8 @@
     {
       "name": "app",
       "image": "<your app image URL here>",
-      "memory": "256",
-      "cpu": "256",
+      "memory": 256,
+      "cpu": 256,
       "essential": true
     }
   ],


### PR DESCRIPTION
Fix the error `Invalid type for parameter containerDefinitions` when registering task in CLI 
(e.g., aws ecs register-task-definition)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
